### PR TITLE
Additional SSL Tweaks

### DIFF
--- a/tasks/site_ssl.yml
+++ b/tasks/site_ssl.yml
@@ -5,16 +5,10 @@
 
 - name: Configure Self Signed Certificate
   block:
-    - name: Create OpenSSL Private Key
-      openssl_privatekey:
-        path: /etc/nginx/certs/{{ domain }}.key
-        size: "{{ privatekey_bits }}"
-      become: yes
-
     - name: Generate Certificate Signing Request
       openssl_csr:
         path:                   /etc/nginx/certs/{{ domain }}.csr
-        privatekey_path:        /etc/nginx/certs/{{ domain }}.key
+        privatekey_path:        /etc/nginx/certs/default.key
         common_name:            "{{ domain }}"
         subject_alt_name:       "DNS:{{ domain }},DNS:www.{{ domain }}"
         country_name:           "{{ country_name | default(omit) }}"
@@ -27,9 +21,10 @@
     - name: Generate Self Signed Certificate
       openssl_certificate:
         path:            /etc/nginx/certs/{{ domain }}.crt
-        privatekey_path: /etc/nginx/certs/{{ domain }}.key
+        privatekey_path: /etc/nginx/certs/default.key
         csr_path:        /etc/nginx/certs/{{ domain }}.csr
         provider:        selfsigned
       become: yes
       notify: Restart Nginx
+      register: ssl_cert_generated
   when: not use_letsencrypt

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -3,7 +3,7 @@
   apt:
     name:
       - "{{ 'python3-pip' if ansible_python.version.major == 3 else 'python-pip' }}"
-      - "{{ 'python3-dev' if ansible_python.version.major == 4 else 'python-dev' }}"
+      - "{{ 'python3-dev' if ansible_python.version.major == 3 else 'python-dev' }}"
       - libssl-dev
       - libffi-dev
     state: present
@@ -58,9 +58,9 @@
   notify: Restart Nginx
 
 - name: Generate DH Params
-  command: openssl dhparam -out /etc/ssl/certs/dhparam.pem {{ dhparam_bits }}
-  args:
-    creates: /etc/ssl/certs/dhparam.pem
+  openssl_dhparam:
+    path: /etc/ssl/certs/dhparam.pem
+    size: "{{ dhparam_bits }}"
   become: yes
   notify: Restart Nginx
 

--- a/templates/site.conf.j2
+++ b/templates/site.conf.j2
@@ -35,7 +35,7 @@ server {
   ssl_certificate_key /etc/letsencrypt/live/{{ domain }}/privkey.pem;
   {% else %}
   ssl_certificate     /etc/nginx/certs/{{ domain }}.crt;
-  ssl_certificate_key /etc/nginx/certs/{{ domain }}.key;
+  ssl_certificate_key /etc/nginx/certs/default.key;
   {% endif %}
 
   # and redirect to the non-www host (declared below)
@@ -59,7 +59,7 @@ server {
   ssl_certificate_key /etc/letsencrypt/live/{{ domain }}/privkey.pem;
   {% else %}
   ssl_certificate     /etc/nginx/certs/{{ domain }}.crt;
-  ssl_certificate_key /etc/nginx/certs/{{ domain }}.key;
+  ssl_certificate_key /etc/nginx/certs/default.key;
   {% endif %}
 {% else %}
   listen [::]:80;


### PR DESCRIPTION
Only create a single private key for the server
Register variable to track if a cert is generated (useful for Vagrant Setup)
Typo fix
Use ansible openssl_dhparam module